### PR TITLE
Multiple shop setup with store codes in the URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "openpay-tripuls/magento2-cards",
+    "name": "openpay/magento2-cards",
     "description": "Credit card payment integration for Magento 2",
     "type": "magento2-module",    
     "minimum-stability": "stable",    


### PR DESCRIPTION
The problem was that the URL_TYPE_WEB does return the base web URL without the store code.
To get the URL with store code included, you need to use URL_TYPE_LINK.
The solution should work in all cases, either with or without store code in URL.
With this solution we are able to get an valid answer from https://********.com/shop/es_MX/openpay/payment/getTypeCard.