### PR TITLE
Mantenimiento compatibilidad magento246

### DIFF
--- a/Model/Config/OrderStatuses.php
+++ b/Model/Config/OrderStatuses.php
@@ -5,6 +5,7 @@ namespace Openpay\Cards\Model\Config;
 class OrderStatuses implements \Magento\Framework\Option\ArrayInterface
 {
     protected $statusCollectionFactory;
+    protected $context;
      
     public function __construct(
 		\Magento\Backend\Block\Template\Context $context,

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -17,7 +17,7 @@
                 <label>Openpay (Tarjetas)</label>
                 <comment>
                     <![CDATA[
-                    <p>Version: 3.4.24</p>
+                    <p>Version: 3.4.25</p>
                     <a href="http://openpay.mx/" target="_blank">Clic aquí para registrar una cuenta con Openpay</a>
                     ]]>
                 </comment>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Openpay_Cards" setup_version="3.4.24">
+    <module name="Openpay_Cards" setup_version="3.4.25">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Checkout" />            


### PR DESCRIPTION
/* Control de Cambios */
Plugin: openpay-cards
Version: 3.4.25
Developer: [gerardo.mendez@openpay.mx]
Type issue: [Mantenimiento]
Country: México, Perú, Colombia
Description: Compatibilidad MAgento 2.4.6
UH: ES6-677