### PR TITLE
Se quita envio de correo doble para ordenes completadas

### DIFF
--- a/Controller/Payment/Success.php
+++ b/Controller/Payment/Success.php
@@ -148,7 +148,6 @@ class Success extends \Magento\Framework\App\Action\Action
             }
 
             $this->checkoutSession->setForceOrderMailSentOnSuccess(true);
-            $this->orderSender->send($order, true);
 
             $order->setState($status)->setStatus($status);
             $order->setTotalPaid($charge->amount);


### PR DESCRIPTION
Plugin: openpay-magento2-cards
Version: 3.5.4
Developer: marcos.vazquez@openpay.mx 
Type issue: feature
Country: MX
Description: Delete email send two times order completed
UH: ES6-1825_Implementar magento 2.4.7