### PR TITLE
Se modifica la referencia de container al checkout success

### DIFF
--- a/Block/Onepage/Success.php
+++ b/Block/Onepage/Success.php
@@ -29,4 +29,15 @@ class Success extends Template
         $this->_isScopePrivate = true;
         $this->httpContext = $httpContext;
     }
+
+    public function getOrderId()
+    {
+        return $this->_checkoutSession->getLastRealOrderId();
+    }
+
+    public function getOrder()
+    {
+        return $this->_checkoutSession->getLastRealOrder();
+    }
+    
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -17,7 +17,7 @@
                 <label>Openpay (Tarjetas)</label>
                 <comment>
                     <![CDATA[
-                    <p>Version: 3.5.12</p>
+                    <p>Version: 3.5.14</p>
                     <a href="http://openpay.mx/" target="_blank">Clic aquí para registrar una cuenta con Openpay</a>
                     ]]>
                 </comment>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Openpay_Cards" setup_version="3.5.12">
+    <module name="Openpay_Cards" setup_version="3.5.14">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Checkout" />            

--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0"?>
 
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">    
-    <body>               
-        <referenceBlock name="page.main.title">
-            <block class="Magento\Checkout\Block\Onepage\Success" name="checkout.success.print.button" template="button.phtml"/>
-            <action method="setPageTitle">
-                <argument translate="true" name="title" xsi:type="string">Thank you for your purchase!</argument>
-            </action>
-        </referenceBlock>
-        <referenceContainer name="content">
-            <block class="Magento\Checkout\Block\Onepage\Success" name="checkout.success" template="Openpay_Cards::save_card_success.phtml" cacheable="false"/>
-            <block class="Magento\Checkout\Block\Registration" name="checkout.registration" template="registration.phtml" cacheable="false"/>
+    <body>
+        <referenceContainer name="checkout.success">
+            <container
+                name="order.success.additional.info" 
+                htmlTag="div" 
+                htmlClass="order-success-additional-info" 
+                after="-" />
         </referenceContainer>
-        <container name="order.success.additional.info" label="Order Success Additional Info"/>
+
+        <referenceContainer name="order.success.additional.info">
+            <block class="Openpay\Cards\Block\Onepage\Success" 
+                name="checkout.success.openpay_cards" 
+                template="Openpay_Cards::save_card_success.phtml" 
+                cacheable="false"/>
+            <block class="Magento\Checkout\Block\Registration" 
+                name="checkout.registration" 
+                template="registration.phtml" 
+                cacheable="false"/>
+        </referenceContainer>
     </body>
 </page>

--- a/view/frontend/templates/save_card_success.phtml
+++ b/view/frontend/templates/save_card_success.phtml
@@ -27,8 +27,12 @@
     .img_notification_card{
         margin-top: 8px;
     }
+
+    .checkout-success-openpay-cards {
+        margin: 20px 0;
+    }
 </style>
-<div class="checkout-success">
+<div class="checkout-success-openpay-cards">
     <?php if ($block->getOrderId()): ?>
 
         <?php if (isset($_SESSION['card_new']) && ($_SESSION['card_new'] == '1' || $_SESSION['card_new'] == '2')): ?>
@@ -41,20 +45,10 @@
             </div>
             <?php unset($_SESSION['card_new']); ?>
         <?php endif; ?>
+
         <?php if ($block->getCanViewOrder()) : ?>
             <p><?php echo __('Your order number is: %1.', sprintf('<a href="%s" class="order-number"><strong>%s</strong></a>', $block->escapeHtml($block->getViewOrderUrl()), $block->escapeHtml($block->getOrderId()))) ?></p>
-        <?php else : ?>
-            <p><?php echo __('Your order # is: <span>%1</span>.', $block->escapeHtml($block->getOrderId())) ?></p>
         <?php endif; ?>
-        <p><?php /* @escapeNotVerified */ echo __('We\'ll email you an order confirmation with details and tracking info.') ?></p>
-
+        
     <?php endif; ?>
-
-    <?php echo $block->getAdditionalInfoHtml() ?>
-
-    <div class="actions-toolbar">
-        <div class="primary">
-            <a class="action primary continue" href="<?php /* @escapeNotVerified */ echo $block->getUrl() ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
-        </div>
-    </div>
 </div>


### PR DESCRIPTION
Plugin: openpay-magento2-cards
Version: 3.5.14
Developer: [marcos.vazquez@openpay.mx](mailto:marcos.vazquez@openpay.mx)
Type issue: [mantenimiento]
Country: MX, PE, CO
Description: Se cambia la referencia del container de checkout success para que no sobreescriba la informacion de magento, si no que la agregue al additional info
UH: EST01-2904